### PR TITLE
Make this library work with psr7 http message version 2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.neon]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fix git issue
+        run: git config --global --add safe.directory /app
+      - name: Composer install
+        uses: php-actions/composer@v6
+      - name: Check code with phpstan
+        run: vendor/bin/phpstan analyze

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,14 @@
 		}
 	},
 	"require-dev": {
-		"php-stubs/wordpress-stubs": "^6.8"
+		"php-stubs/wordpress-stubs": "^6.8",
+		"phpstan/phpstan": "^2.1",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"phpstan/extension-installer": "^1.4"
+	},
+	"config": {
+		"allow-plugins": {
+			"phpstan/extension-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,6 @@
 		"psr/http-message": "^2.0",
 		"league/uri": "^7.5"
 	},
-	"repositories": [
-		{
-			"type": "git",
-			"url": "git@github.com:papertower/WP-REST-API-PSR7.git"
-		}
-	],
 	"keywords": ["wp rest api", "wordpress", "psr-7"],
 	"authors": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,31 @@
 {
-    "name": "papertower/wp-rest-api-psr7",
-    "description": "Provides PSR-7 and WP REST API Response and Request classes",
-    "type": "library",
-    "license": "MIT",
-    "require": {
-        "psr/http-message": "^1.0.1"
-    },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "git@github.com:papertower/WP-REST-API-PSR7.git"
-        }
-    ],
-    "keywords": [
-        "wp rest api",
-        "wordpress",
-        "psr-7"
-    ],
-    "authors": [
-        {
-            "name": "Jason Adams",
-            "email": "jason@papertower.com"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "WPRestApi\\PSR7\\": "src/"
-        }
-    }
+	"name": "papertower/wp-rest-api-psr7",
+	"description": "Provides PSR-7 and WP REST API Response and Request classes",
+	"type": "library",
+	"license": "MIT",
+	"require": {
+		"psr/http-message": "^2.0",
+		"league/uri": "^7.5"
+	},
+	"repositories": [
+		{
+			"type": "git",
+			"url": "git@github.com:papertower/WP-REST-API-PSR7.git"
+		}
+	],
+	"keywords": ["wp rest api", "wordpress", "psr-7"],
+	"authors": [
+		{
+			"name": "Jason Adams",
+			"email": "jason@papertower.com"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"WPRestApi\\PSR7\\": "src/"
+		}
+	},
+	"require-dev": {
+		"php-stubs/wordpress-stubs": "^6.8"
+	}
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+    paths:
+        - src
+    ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: throws.unusedType
+        - identifier: missingType.generics

--- a/src/BodyStream.php
+++ b/src/BodyStream.php
@@ -18,16 +18,41 @@ class BodyStream implements StreamInterface
     /** @var array Hash of readable and writable stream types */
     private static $readWriteHash = [
         'read' => [
-            'r' => true, 'w+' => true, 'r+' => true, 'x+' => true, 'c+' => true,
-            'rb' => true, 'w+b' => true, 'r+b' => true, 'x+b' => true,
-            'c+b' => true, 'rt' => true, 'w+t' => true, 'r+t' => true,
-            'x+t' => true, 'c+t' => true, 'a+' => true
+            'r' => true,
+            'w+' => true,
+            'r+' => true,
+            'x+' => true,
+            'c+' => true,
+            'rb' => true,
+            'w+b' => true,
+            'r+b' => true,
+            'x+b' => true,
+            'c+b' => true,
+            'rt' => true,
+            'w+t' => true,
+            'r+t' => true,
+            'x+t' => true,
+            'c+t' => true,
+            'a+' => true
         ],
         'write' => [
-            'w' => true, 'w+' => true, 'rw' => true, 'r+' => true, 'x+' => true,
-            'c+' => true, 'wb' => true, 'w+b' => true, 'r+b' => true,
-            'x+b' => true, 'c+b' => true, 'w+t' => true, 'r+t' => true,
-            'x+t' => true, 'c+t' => true, 'a' => true, 'a+' => true
+            'w' => true,
+            'w+' => true,
+            'rw' => true,
+            'r+' => true,
+            'x+' => true,
+            'c+' => true,
+            'wb' => true,
+            'w+b' => true,
+            'r+b' => true,
+            'x+b' => true,
+            'c+b' => true,
+            'w+t' => true,
+            'r+t' => true,
+            'x+t' => true,
+            'c+t' => true,
+            'a' => true,
+            'a+' => true
         ]
     ];
 
@@ -95,7 +120,7 @@ class BodyStream implements StreamInterface
         }
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $contents = stream_get_contents($this->stream);
 
@@ -106,7 +131,7 @@ class BodyStream implements StreamInterface
         return $contents;
     }
 
-    public function close()
+    public function close(): void
     {
         if (isset($this->stream)) {
             if (is_resource($this->stream)) {
@@ -130,7 +155,10 @@ class BodyStream implements StreamInterface
         return $result;
     }
 
-    public function getSize()
+    /**
+     * {@inheritDoc}
+     */
+    public function getSize(): ?int
     {
         if ($this->size !== null) {
             return $this->size;
@@ -154,27 +182,42 @@ class BodyStream implements StreamInterface
         return null;
     }
 
-    public function isReadable()
+    /**
+     * {@inheritDoc}
+     */
+    public function isReadable(): bool
     {
         return $this->readable;
     }
 
-    public function isWritable()
+    /**
+     * {@inheritDoc}
+     */
+    public function isWritable(): bool
     {
         return $this->writable;
     }
 
-    public function isSeekable()
+    /**
+     * {@inheritDoc}
+     */
+    public function isSeekable(): bool
     {
         return $this->seekable;
     }
 
-    public function eof()
+    /**
+     * {@inheritDoc}
+     */
+    public function eof(): bool
     {
         return !$this->stream || feof($this->stream);
     }
 
-    public function tell()
+    /**
+     * {@inheritDoc}
+     */
+    public function tell(): int
     {
         $result = ftell($this->stream);
 
@@ -185,22 +228,31 @@ class BodyStream implements StreamInterface
         return $result;
     }
 
-    public function rewind()
+    /**
+     * {@inheritDoc}
+     */
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    /**
+     * {@inheritDoc}
+     */
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if (!$this->seekable) {
             throw new \RuntimeException('Stream is not seekable');
         } elseif (fseek($this->stream, $offset, $whence) === -1) {
             throw new \RuntimeException('Unable to seek to stream position '
-                                        . $offset . ' with whence ' . var_export($whence, true));
+                . $offset . ' with whence ' . var_export($whence, true));
         }
     }
 
-    public function read($length)
+    /**
+     * {@inheritDoc}
+     */
+    public function read($length): string
     {
         if (!$this->readable) {
             throw new \RuntimeException('Cannot read from non-readable stream');
@@ -221,7 +273,10 @@ class BodyStream implements StreamInterface
         return $string;
     }
 
-    public function write($string)
+    /**
+     * {@inheritDoc}
+     */
+    public function write($string): int
     {
         if (!$this->writable) {
             throw new \RuntimeException('Cannot write to a non-writable stream');
@@ -253,3 +308,4 @@ class BodyStream implements StreamInterface
         return isset($meta[$key]) ? $meta[$key] : null;
     }
 }
+

--- a/src/BodyStream.php
+++ b/src/BodyStream.php
@@ -7,13 +7,13 @@ use Psr\Http\Message\StreamInterface;
 
 class BodyStream implements StreamInterface
 {
-    private $stream;
-    private $size;
-    private $seekable;
-    private $readable;
-    private $writable;
-    private $uri;
-    private $customMetadata;
+    private mixed $stream;
+    private mixed $size;
+    private bool $seekable;
+    private bool $readable;
+    private bool $writable;
+    private mixed $uri;
+    private mixed $customMetadata;
 
     /** @var array Hash of readable and writable stream types */
     private static $readWriteHash = [
@@ -93,7 +93,7 @@ class BodyStream implements StreamInterface
         $this->uri = $this->getMetadata('uri');
     }
 
-    public function __get($name)
+    public function __get(string $name): void
     {
         if ($name == 'stream') {
             throw new \RuntimeException('The stream is detached');
@@ -308,4 +308,3 @@ class BodyStream implements StreamInterface
         return isset($meta[$key]) ? $meta[$key] : null;
     }
 }
-

--- a/src/RequestUri.php
+++ b/src/RequestUri.php
@@ -3,7 +3,7 @@
 
 namespace WPRestApi\PSR7;
 
-
+use League\Uri\UriResolver;
 use Psr\Http\Message\UriInterface;
 
 class RequestUri implements UriInterface
@@ -116,7 +116,7 @@ class RequestUri implements UriInterface
             $uri .= $scheme . ':';
         }
 
-        if ($authority != ''|| $scheme === 'file') {
+        if ($authority != '' || $scheme === 'file') {
             $uri .= '//' . $authority;
         }
 
@@ -146,7 +146,7 @@ class RequestUri implements UriInterface
     public static function isDefaultPort(UriInterface $uri)
     {
         return $uri->getPort() === null
-               || (isset(self::$defaultPorts[$uri->getScheme()]) && $uri->getPort() === self::$defaultPorts[$uri->getScheme()]);
+            || (isset(self::$defaultPorts[$uri->getScheme()]) && $uri->getPort() === self::$defaultPorts[$uri->getScheme()]);
     }
 
     /**
@@ -200,9 +200,9 @@ class RequestUri implements UriInterface
     public static function isAbsolutePathReference(UriInterface $uri)
     {
         return $uri->getScheme() === ''
-               && $uri->getAuthority() === ''
-               && isset($uri->getPath()[0])
-               && $uri->getPath()[0] === '/';
+            && $uri->getAuthority() === ''
+            && isset($uri->getPath()[0])
+            && $uri->getPath()[0] === '/';
     }
 
     /**
@@ -218,8 +218,8 @@ class RequestUri implements UriInterface
     public static function isRelativePathReference(UriInterface $uri)
     {
         return $uri->getScheme() === ''
-               && $uri->getAuthority() === ''
-               && (!isset($uri->getPath()[0]) || $uri->getPath()[0] !== '/');
+            && $uri->getAuthority() === ''
+            && (!isset($uri->getPath()[0]) || $uri->getPath()[0] !== '/');
     }
 
     /**
@@ -241,27 +241,12 @@ class RequestUri implements UriInterface
             $uri = UriResolver::resolve($base, $uri);
 
             return ($uri->getScheme() === $base->getScheme())
-                   && ($uri->getAuthority() === $base->getAuthority())
-                   && ($uri->getPath() === $base->getPath())
-                   && ($uri->getQuery() === $base->getQuery());
+                && ($uri->getAuthority() === $base->getAuthority())
+                && ($uri->getPath() === $base->getPath())
+                && ($uri->getQuery() === $base->getQuery());
         }
 
         return $uri->getScheme() === '' && $uri->getAuthority() === '' && $uri->getPath() === '' && $uri->getQuery() === '';
-    }
-
-    /**
-     * Removes dot segments from a path and returns the new path.
-     *
-     * @param string $path
-     *
-     * @return string
-     *
-     * @deprecated since version 1.4. Use UriResolver::removeDotSegments instead.
-     * @see UriResolver::removeDotSegments
-     */
-    public static function removeDotSegments($path)
-    {
-        return UriResolver::removeDotSegments($path);
     }
 
     /**
@@ -371,12 +356,12 @@ class RequestUri implements UriInterface
         return $uri;
     }
 
-    public function getScheme()
+    public function getScheme(): string
     {
         return $this->scheme;
     }
 
-    public function getAuthority()
+    public function getAuthority(): string
     {
         $authority = $this->host;
         if ($this->userInfo !== '') {
@@ -390,37 +375,37 @@ class RequestUri implements UriInterface
         return $authority;
     }
 
-    public function getUserInfo()
+    public function getUserInfo(): string
     {
         return $this->userInfo;
     }
 
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
 
-    public function getPort()
+    public function getPort(): int|null
     {
         return $this->port;
     }
 
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
-    public function getQuery()
+    public function getQuery(): string
     {
         return $this->query;
     }
 
-    public function getFragment()
+    public function getFragment(): string
     {
         return $this->fragment;
     }
 
-    public function withScheme($scheme)
+    public function withScheme($scheme): static
     {
         $scheme = $this->filterScheme($scheme);
 
@@ -436,7 +421,7 @@ class RequestUri implements UriInterface
         return $new;
     }
 
-    public function withUserInfo($user, $password = null)
+    public function withUserInfo($user, $password = null): static
     {
         $info = $user;
         if ($password != '') {
@@ -454,7 +439,7 @@ class RequestUri implements UriInterface
         return $new;
     }
 
-    public function withHost($host)
+    public function withHost($host): static
     {
         $host = $this->filterHost($host);
 
@@ -469,7 +454,7 @@ class RequestUri implements UriInterface
         return $new;
     }
 
-    public function withPort($port)
+    public function withPort($port): static
     {
         $port = $this->filterPort($port);
 
@@ -485,7 +470,7 @@ class RequestUri implements UriInterface
         return $new;
     }
 
-    public function withPath($path)
+    public function withPath($path): static
     {
         $path = $this->filterPath($path);
 
@@ -500,7 +485,7 @@ class RequestUri implements UriInterface
         return $new;
     }
 
-    public function withQuery($query)
+    public function withQuery($query): static
     {
         $query = $this->filterQueryAndFragment($query);
 
@@ -514,7 +499,7 @@ class RequestUri implements UriInterface
         return $new;
     }
 
-    public function withFragment($fragment)
+    public function withFragment($fragment): static
     {
         $fragment = $this->filterQueryAndFragment($fragment);
 
@@ -688,10 +673,10 @@ class RequestUri implements UriInterface
         } elseif (isset($this->path[0]) && $this->path[0] !== '/') {
             @trigger_error(
                 'The path of a URI with an authority must start with a slash "/" or be empty. Automagically fixing the URI ' .
-                'by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.',
+                    'by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.',
                 E_USER_DEPRECATED
             );
-            $this->path = '/'. $this->path;
+            $this->path = '/' . $this->path;
             //throw new \InvalidArgumentException('The path of a URI with an authority must start with a slash "/" or be empty');
         }
     }

--- a/src/RequestUri.php
+++ b/src/RequestUri.php
@@ -16,7 +16,7 @@ class RequestUri implements UriInterface
      */
     const HTTP_DEFAULT_HOST = 'localhost';
 
-    private static $defaultPorts = [
+    private static array $defaultPorts = [
         'http'  => 80,
         'https' => 443,
         'ftp' => 21,
@@ -30,9 +30,9 @@ class RequestUri implements UriInterface
         'ldap' => 389,
     ];
 
-    private static $charUnreserved = 'a-zA-Z0-9_\-\.~';
-    private static $charSubDelims = '!\$&\'\(\)\*\+,;=';
-    private static $replaceQuery = ['=' => '%3D', '&' => '%26'];
+    private static string $charUnreserved = 'a-zA-Z0-9_\-\.~';
+    private static string $charSubDelims = '!\$&\'\(\)\*\+,;=';
+    private static array $replaceQuery = ['=' => '%3D', '&' => '%26'];
 
     /** @var string Uri scheme. */
     private $scheme = '';
@@ -518,7 +518,7 @@ class RequestUri implements UriInterface
      *
      * @param array $parts Array of parse_url parts to apply.
      */
-    private function applyParts(array $parts)
+    private function applyParts(array $parts): void
     {
         $this->scheme = isset($parts['scheme'])
             ? $this->filterScheme($parts['scheme'])
@@ -550,15 +550,9 @@ class RequestUri implements UriInterface
      * @param string $scheme
      *
      * @return string
-     *
-     * @throws \InvalidArgumentException If the scheme is invalid.
      */
-    private function filterScheme($scheme)
+    private function filterScheme(string $scheme)
     {
-        if (!is_string($scheme)) {
-            throw new \InvalidArgumentException('Scheme must be a string');
-        }
-
         return strtolower($scheme);
     }
 
@@ -566,15 +560,9 @@ class RequestUri implements UriInterface
      * @param string $host
      *
      * @return string
-     *
-     * @throws \InvalidArgumentException If the host is invalid.
      */
-    private function filterHost($host)
+    private function filterHost(string $host)
     {
-        if (!is_string($host)) {
-            throw new \InvalidArgumentException('Host must be a string');
-        }
-
         return strtolower($host);
     }
 
@@ -601,7 +589,7 @@ class RequestUri implements UriInterface
         return $port;
     }
 
-    private function removeDefaultPort()
+    private function removeDefaultPort(): void
     {
         if ($this->port !== null && self::isDefaultPort($this)) {
             $this->port = null;
@@ -614,15 +602,9 @@ class RequestUri implements UriInterface
      * @param string $path
      *
      * @return string
-     *
-     * @throws \InvalidArgumentException If the path is invalid.
      */
-    private function filterPath($path)
+    private function filterPath(string $path)
     {
-        if (!is_string($path)) {
-            throw new \InvalidArgumentException('Path must be a string');
-        }
-
         return preg_replace_callback(
             '/(?:[^' . self::$charUnreserved . self::$charSubDelims . '%:@\/]++|%(?![A-Fa-f0-9]{2}))/',
             [$this, 'rawurlencodeMatchZero'],
@@ -636,15 +618,9 @@ class RequestUri implements UriInterface
      * @param string $str
      *
      * @return string
-     *
-     * @throws \InvalidArgumentException If the query or fragment is invalid.
      */
     private function filterQueryAndFragment($str)
     {
-        if (!is_string($str)) {
-            throw new \InvalidArgumentException('Query and fragment must be a string');
-        }
-
         return preg_replace_callback(
             '/(?:[^' . self::$charUnreserved . self::$charSubDelims . '%:@\/\?]++|%(?![A-Fa-f0-9]{2}))/',
             [$this, 'rawurlencodeMatchZero'],
@@ -652,12 +628,12 @@ class RequestUri implements UriInterface
         );
     }
 
-    private function rawurlencodeMatchZero(array $match)
+    private function rawurlencodeMatchZero(array $match): string
     {
         return rawurlencode($match[0]);
     }
 
-    private function validateState()
+    private function validateState(): void
     {
         if ($this->host === '' && ($this->scheme === 'http' || $this->scheme === 'https')) {
             $this->host = self::HTTP_DEFAULT_HOST;

--- a/src/WP_REST_PSR7_Request.php
+++ b/src/WP_REST_PSR7_Request.php
@@ -44,7 +44,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return string HTTP protocol version.
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
@@ -63,7 +63,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): static
     {
         $clone           = clone $this;
         $clone->protocol = $version;
@@ -96,7 +96,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *     key MUST be a header name, and each value MUST be an array of strings
      *     for that header.
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -110,7 +110,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         return isset($this->headers[$name]);
     }
@@ -130,7 +130,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         $header = $this->get_header_as_array($name);
 
@@ -157,7 +157,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *    concatenated together using a comma. If the header does not appear in
      *    the message, this method MUST return an empty string.
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine($name): string
     {
         $line = $this->get_header($name);
 
@@ -180,7 +180,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($name, $value)
+    public function withHeader($name, $value): static
     {
         $clone = clone $this;
         $clone->set_header($name, $value);
@@ -205,7 +205,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader($name, $value): static
     {
         $clone = clone $this;
         $clone->add_header($name, $value);
@@ -226,7 +226,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return static
      */
-    public function withoutHeader($name)
+    public function withoutHeader($name): static
     {
         $clone = clone $this;
         $clone->remove_header($name);
@@ -239,9 +239,9 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return StreamInterface Returns the body as a stream.
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
-        if ( ! isset($this->bodyStream)) {
+        if (! isset($this->bodyStream)) {
             $stream = fopen('php://temp', 'r+');
             if ($this->body !== '') {
                 fwrite($stream, $this->body);
@@ -268,7 +268,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      * @return static
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): static
     {
         if ($body === $this->bodyStream) {
             return $this;
@@ -297,7 +297,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return string
      */
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         if (null !== $this->requestTarget) {
             return $this->requestTarget;
@@ -309,7 +309,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
         }
 
         $query = $this->uri->getQuery();
-        if ( ! empty($query)) {
+        if (! empty($query)) {
             $target .= "?{$query}";
         }
 
@@ -335,10 +335,10 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return static
      */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget($requestTarget): static
     {
         if (strpos($requestTarget, ' ')) {
-            throw new InvalidArgumentException(
+            throw new \InvalidArgumentException(
                 'Invalid request target provided; cannot contain whitespace'
             );
         }
@@ -354,7 +354,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return string Returns the request method.
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -375,7 +375,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      * @return static
      * @throws \InvalidArgumentException for invalid HTTP methods.
      */
-    public function withMethod($method)
+    public function withMethod($method): static
     {
         $clone         = clone $this;
         $clone->method = $method;
@@ -392,7 +392,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      * @return UriInterface Returns a UriInterface instance
      *     representing the URI of the request.
      */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->uri;
     }
@@ -429,7 +429,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
      *
      * @return static
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, $preserveHost = false): static
     {
         if ($uri === $this->uri) {
             return $this;
@@ -438,8 +438,8 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
         $clone      = clone $this;
         $clone->uri = $uri;
 
-        if ( ! $preserveHost) {
-           $clone->updateHostFromUri();
+        if (! $preserveHost) {
+            $clone->updateHostFromUri();
         }
 
         return $clone;

--- a/src/WP_REST_PSR7_Request.php
+++ b/src/WP_REST_PSR7_Request.php
@@ -10,13 +10,14 @@ use Psr\Http\Message\UriInterface;
 
 class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
 {
-    protected $protocol = '1.1';
-    protected $bodyStream;
-    protected $uri;
-    protected $requestTarget;
+    protected string $protocol = '1.1';
+    protected BodyStream|StreamInterface|null $bodyStream;
+    protected RequestUri|UriInterface $uri;
+    protected ?string $requestTarget;
 
-    public static function fromRequest(\WP_REST_Request $request)
+    public static function fromRequest(\WP_REST_Request $request): static
     {
+        /** @phpstan-ignore new.static */
         $psr7_request = new static(
             $request->get_method(),
             $request->get_route(),
@@ -445,7 +446,7 @@ class WP_REST_PSR7_Request extends \WP_REST_Request implements RequestInterface
         return $clone;
     }
 
-    private function updateHostFromUri()
+    private function updateHostFromUri(): void
     {
         $host = $this->uri->getHost();
 

--- a/src/WP_REST_PSR7_Response.php
+++ b/src/WP_REST_PSR7_Response.php
@@ -77,7 +77,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
     protected $protocol = '1.1';
 
     /**
-     * @var BodyStream Stream for the data
+     * @var BodyStream|StreamInterface|null Stream for the data
      */
     protected $bodyStream;
 
@@ -105,7 +105,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
     /**
      * Adds the reasonPhrase property to the parent constructor.
      *
-     * @param null  $data
+     * @param string|null  $data
      * @param int   $status
      * @param array $headers
      */
@@ -434,4 +434,3 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
         }
     }
 }
-

--- a/src/WP_REST_PSR7_Response.php
+++ b/src/WP_REST_PSR7_Response.php
@@ -125,7 +125,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *
      * @return string HTTP protocol version.
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
@@ -144,7 +144,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): static
     {
         $clone           = clone $this;
         $clone->protocol = $version;
@@ -177,7 +177,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *     key MUST be a header name, and each value MUST be an array of strings
      *     for that header.
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->get_headers();
     }
@@ -191,7 +191,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($name)
+    public function hasHeader($name): bool
     {
         return isset($this->headers[$name]);
     }
@@ -211,7 +211,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
-    public function getHeader($name)
+    public function getHeader($name): array
     {
         return isset($this->headers[$name]) ? $this->headers[$name] : [];
     }
@@ -236,7 +236,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *    concatenated together using a comma. If the header does not appear in
      *    the message, this method MUST return an empty string.
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine($name): string
     {
         return implode(',', $this->getHeader($name));
     }
@@ -257,7 +257,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($name, $value)
+    public function withHeader($name, $value): static
     {
         $clone = clone $this;
         $clone->header($name, $value);
@@ -282,7 +282,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader($name, $value): static
     {
         $clone = clone $this;
         $clone->header($name, $value, false);
@@ -303,7 +303,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *
      * @return static
      */
-    public function withoutHeader($name)
+    public function withoutHeader($name): static
     {
         $clone = clone $this;
         unset($clone->headers[$name]);
@@ -316,9 +316,9 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *
      * @return StreamInterface Returns the body as a stream.
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
-        if ( ! isset($this->bodyStream)) {
+        if (! isset($this->bodyStream)) {
             $stream = fopen('php://temp', 'r+');
             if ($this->data !== '') {
                 fwrite($stream, $this->data);
@@ -345,7 +345,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      * @return static
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): static
     {
         if ($body === $this->bodyStream) {
             return $this;
@@ -366,7 +366,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      *
      * @return int Status code.
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->get_status();
     }
@@ -393,7 +393,7 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      * @return static
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = ''): static
     {
         $clone         = clone $this;
         $clone->status = (int)$code;
@@ -420,17 +420,18 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @return string Reason phrase; must return an empty string if none present.
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->reasonPhrase;
     }
 
     public function get_data()
     {
-        if ( isset($this->bodyStream) ) {
+        if (isset($this->bodyStream)) {
             return json_decode($this->bodyStream);
         } else {
             return parent::get_data();
         }
     }
 }
+

--- a/src/WP_REST_PSR7_Response.php
+++ b/src/WP_REST_PSR7_Response.php
@@ -95,10 +95,24 @@ class WP_REST_PSR7_Response extends \WP_REST_Response implements ResponseInterfa
      */
     public static function fromPSR7Response(ResponseInterface $response)
     {
+        // Since PSR7 response has the headers as an array of arrays,
+        // we need to convert it to a simple associative array
+        $headers = [];
+        $responseHeaders = $response->getHeaders();
+        foreach ($responseHeaders as $name => $values) {
+            // If for some reason the values is a string, we set it directly
+            if (is_string($values)) {
+                $headers[$name] = $values;
+            }
+            // Set the first value as the header value
+            if (isset($values[0])) {
+                $headers[$name] = $values[0];
+            }
+        }
         return new self(
             (string)$response->getBody(),
             $response->getStatusCode(),
-            $response->getHeaders()
+            $headers,
         );
     }
 

--- a/src/WP_REST_PSR7_ServerRequest.php
+++ b/src/WP_REST_PSR7_ServerRequest.php
@@ -27,7 +27,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return array
      */
-    public function getServerParams()
+    public function getServerParams(): array
     {
         return $this->serverParams;
     }
@@ -42,7 +42,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return array
      */
-    public function getCookieParams()
+    public function getCookieParams(): array
     {
         return $this->cookieParams;
     }
@@ -65,7 +65,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return static
      */
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): static
     {
         $clone               = clone $this;
         $clone->cookieParams = $cookies;
@@ -85,7 +85,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return array
      */
-    public function getQueryParams()
+    public function getQueryParams(): array
     {
         return $this->get_query_params();
     }
@@ -113,7 +113,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return static
      */
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): static
     {
         $clone                = clone $this;
         $clone->params['GET'] = $query;
@@ -133,7 +133,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      * @return array An array tree of UploadedFileInterface instances; an empty
      *     array MUST be returned if no data is present.
      */
-    public function getUploadedFiles()
+    public function getUploadedFiles(): array
     {
         return $this->get_file_params();
     }
@@ -150,7 +150,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      * @return static
      * @throws \InvalidArgumentException if an invalid structure is provided.
      */
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): static
     {
         $clone = clone $this;
         $clone->params['FILES'] = $uploadedFiles;
@@ -206,7 +206,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      * @throws \InvalidArgumentException if an unsupported argument type is
      *     provided.
      */
-    public function withParsedBody($data)
+    public function withParsedBody($data): static
     {
         $clone                 = clone $this;
         $clone->params['POST'] = $data;
@@ -225,7 +225,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return array Attributes derived from the request.
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->get_attributes();
     }
@@ -269,7 +269,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return static
      */
-    public function withAttribute($name, $value)
+    public function withAttribute($name, $value): static
     {
         $clone                    = clone $this;
         $clone->attributes[$name] = $value;
@@ -293,7 +293,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *
      * @return static
      */
-    public function withoutAttribute($name)
+    public function withoutAttribute($name): static
     {
         $clone = clone $this;
         unset($clone->attributes[$name]);
@@ -301,3 +301,4 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
         return $clone;
     }
 }
+

--- a/src/WP_REST_PSR7_ServerRequest.php
+++ b/src/WP_REST_PSR7_ServerRequest.php
@@ -8,8 +8,8 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerRequestInterface
 {
-    protected $serverParams;
-    protected $cookieParams;
+    protected array $serverParams;
+    protected array $cookieParams;
 
     public function __construct($method = '', $route = '', array $attributes = [])
     {
@@ -203,8 +203,7 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
      *                                typically be in an array or object.
      *
      * @return static
-     * @throws \InvalidArgumentException if an unsupported argument type is
-     *     provided.
+     * @throws \InvalidArgumentException if an unsupported argument type is provided.
      */
     public function withParsedBody($data): static
     {
@@ -301,4 +300,3 @@ class WP_REST_PSR7_ServerRequest extends WP_REST_PSR7_Request implements ServerR
         return $clone;
     }
 }
-


### PR DESCRIPTION
Hello,

Thanks a lot for making this library, it has helped a lot.
I wanted to share some improvements that can make the library work with [psr7 http message version 2.0](https://github.com/php-fig/http-message/releases/tag/2.0).
This PR solves some breaking changes that are in v2 of the psr7 interfaces.

I have also added a github actions workflow to validate the code with phpstan to make sure there are no obvious errors.

I have also removed the repositories key from the composer.json, because that key is used to get packages from other repositories, not to define the git repository of the package ([source](https://getcomposer.org/doc/04-schema.md#repositories)).